### PR TITLE
Set program homepage to meditrax.ca

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typescript",
     "healthcare"
   ],
-  "homepage": "https://dizzafizza.github.io/Meditrax",
+  "homepage": "https://www.meditrax.ca/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dizzafizza/Meditrax.git"

--- a/public/404.html
+++ b/public/404.html
@@ -19,7 +19,7 @@
       // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
       // This way the code will only replace the route part and not the real directory.
       // If you're using a custom domain, set pathSegmentsToKeep to 0.
-      var pathSegmentsToKeep = 1;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,5 +27,5 @@ export default defineConfig({
       },
     },
   },
-  base: '/Meditrax/', // Use absolute base path matching homepage
+  base: '/', // Use root path for custom domain
 })


### PR DESCRIPTION
Set the application's homepage to `https://www.meditrax.ca/` and update build/routing configurations for custom domain deployment.

The application was previously configured for GitHub Pages under a subdirectory (`/Meditrax/`). These changes align the `package.json` homepage, `vite.config.ts` base path, and `public/404.html` routing logic to correctly support deployment to the custom domain `www.meditrax.ca`.

---
<a href="https://cursor.com/background-agent?bcId=bc-05a80a32-9e0b-4af0-9906-a3326849c535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05a80a32-9e0b-4af0-9906-a3326849c535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

