### PR TITLE
Add Capsule Calculator for hand-filling capsules from bulk powder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ import Inventory from "@/pages/Inventory";
 import TaperPlanner from "@/pages/TaperPlanner";
 import TaperDetail from "@/pages/TaperDetail";
 import CyclicDosing from "@/pages/CyclicDosing";
+import CapsuleCalculator from "@/pages/CapsuleCalculator";
 import KnowledgeBase from "@/pages/KnowledgeBase";
 import KnowledgeArticle from "@/pages/KnowledgeArticle";
 import Assistant from "@/pages/Assistant";
@@ -68,6 +69,7 @@ function App() {
                     <Route path="/taper" element={<TaperPlanner />} />
                     <Route path="/taper/:id" element={<TaperDetail />} />
                     <Route path="/cyclic" element={<CyclicDosing />} />
+                    <Route path="/capsules" element={<CapsuleCalculator />} />
                     <Route path="/knowledge" element={<KnowledgeBase />} />
                     <Route path="/knowledge/:id" element={<KnowledgeArticle />} />
                     <Route path="/assistant" element={<Assistant />} />

--- a/frontend/src/constants/testIds/capsule.js
+++ b/frontend/src/constants/testIds/capsule.js
@@ -1,0 +1,23 @@
+// Test IDs for the Capsule Calculator feature. Naming follows the directive
+// in ./auth.js (keys camelCase, values kebab-case `<feature>-<element>`).
+
+export const CAPSULE = {
+	// Bag → Capsules
+	totalInput: 'capsule-total-input',
+	totalUnitSelect: 'capsule-total-unit-select',
+	fillInput: 'capsule-fill-input',
+	sizeSelect: 'capsule-size-select',
+	densitySelect: 'capsule-density-select',
+	densityCustomInput: 'capsule-density-custom-input',
+	purityInput: 'capsule-purity-input',
+	resultCount: 'capsule-result-count',
+	// Reverse
+	capsulesInput: 'capsule-count-input',
+	// Cost
+	bagCostInput: 'capsule-bag-cost-input',
+	// Actions
+	copyButton: 'capsule-copy-button',
+	saveInventoryButton: 'capsule-save-inventory-button',
+	saveInventoryConfirm: 'capsule-save-inventory-confirm',
+	medSelect: 'capsule-med-select',
+};

--- a/frontend/src/constants/testIds/index.js
+++ b/frontend/src/constants/testIds/index.js
@@ -13,3 +13,4 @@
 
 export * from './auth';
 export * from './home';
+export * from './capsule';

--- a/frontend/src/lib/__tests__/capsuleCalc.test.js
+++ b/frontend/src/lib/__tests__/capsuleCalc.test.js
@@ -1,0 +1,134 @@
+import {
+  CAPSULE_SIZES,
+  toMg,
+  fromMg,
+  convertMass,
+  capsuleCapacityMg,
+  bagToCapsules,
+  capsulesToPowder,
+  fillerPlan,
+  costPer,
+  formatMass,
+} from "../capsuleCalc";
+
+describe("unit conversion", () => {
+  test("toMg converts common units", () => {
+    expect(toMg(1, "g")).toBe(1000);
+    expect(toMg(1000, "mcg")).toBe(1);
+    expect(toMg(5, "mg")).toBe(5);
+  });
+
+  test("round-trips through mg", () => {
+    expect(fromMg(toMg(2.5, "g"), "g")).toBeCloseTo(2.5, 6);
+    expect(convertMass(1, "oz", "g")).toBeCloseTo(28.349523125, 6);
+    expect(convertMass(1, "g", "oz")).toBeCloseTo(1 / 28.349523125, 9);
+  });
+
+  test("bad units/values are defensive", () => {
+    expect(toMg(NaN, "mg")).toBe(0);
+    expect(fromMg(100, "bogus")).toBe(100); // unknown unit → factor 1
+  });
+});
+
+describe("capsuleCapacityMg", () => {
+  test("size 0 at 0.6 g/mL ≈ 408 mg", () => {
+    // 0.68 mL × 0.6 g/mL × 1000 = 408 mg
+    expect(capsuleCapacityMg("0", 0.6)).toBeCloseTo(408, 1);
+  });
+
+  test("unknown size → 0", () => {
+    expect(capsuleCapacityMg("99", 0.6)).toBe(0);
+  });
+
+  test("all standard sizes are defined", () => {
+    ["000", "00", "0", "1", "2", "3", "4", "5"].forEach((k) => {
+      expect(CAPSULE_SIZES[k]).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("bagToCapsules", () => {
+  test("50 g @ 250 mg fill → 200 capsules, no leftover", () => {
+    const r = bagToCapsules({ totalAmount: 50, totalUnit: "g", fillPerCapsuleMg: 250, purityPct: 100 });
+    expect(r.capsules).toBe(200);
+    expect(r.leftoverMg).toBe(0);
+    expect(r.totalActiveMg).toBe(50000);
+  });
+
+  test("purity < 100 increases material per capsule and lowers count", () => {
+    const full = bagToCapsules({ totalAmount: 50, totalUnit: "g", fillPerCapsuleMg: 250, purityPct: 100 });
+    const half = bagToCapsules({ totalAmount: 50, totalUnit: "g", fillPerCapsuleMg: 250, purityPct: 50 });
+    expect(half.materialPerCapsuleMg).toBeCloseTo(full.materialPerCapsuleMg * 2, 3);
+    expect(half.capsules).toBe(100);
+  });
+
+  test("reports leftover powder", () => {
+    const r = bagToCapsules({ totalAmount: 1000, totalUnit: "mg", fillPerCapsuleMg: 300, purityPct: 100 });
+    expect(r.capsules).toBe(3);
+    expect(r.leftoverMg).toBeCloseTo(100, 3);
+  });
+
+  test("zero / missing inputs → zero capsules, all leftover", () => {
+    const r = bagToCapsules({ totalAmount: 10, totalUnit: "g", fillPerCapsuleMg: 0 });
+    expect(r.capsules).toBe(0);
+    expect(r.leftoverMg).toBe(10000);
+  });
+});
+
+describe("capsulesToPowder (reverse)", () => {
+  test("100 capsules × 200 mg → 20 g", () => {
+    const r = capsulesToPowder({ numCapsules: 100, fillPerCapsuleMg: 200, purityPct: 100 });
+    expect(r.totalMaterialMg).toBe(20000);
+    expect(r.totalActiveMg).toBe(20000);
+  });
+
+  test("purity increases required material", () => {
+    const r = capsulesToPowder({ numCapsules: 100, fillPerCapsuleMg: 200, purityPct: 50 });
+    expect(r.totalMaterialMg).toBe(40000);
+    expect(r.totalActiveMg).toBe(20000);
+  });
+});
+
+describe("fillerPlan", () => {
+  test("small dose leaves room for filler", () => {
+    const r = fillerPlan({ sizeKey: "0", densityGPerMl: 0.6, activeDoseMg: 8, purityPct: 100, numCapsules: 30 });
+    expect(r.capacityMg).toBeCloseTo(408, 1);
+    expect(r.fillerPerCapsuleMg).toBeCloseTo(400, 1);
+    expect(r.totalFillerMg).toBeCloseTo(12000, 0);
+    expect(r.totalActiveMg).toBe(240);
+    expect(r.warning).toBe("");
+  });
+
+  test("dose exceeding capacity → warning, no negative filler", () => {
+    const r = fillerPlan({ sizeKey: "5", densityGPerMl: 0.6, activeDoseMg: 500, numCapsules: 10 });
+    expect(r.warning).toMatch(/won't fit/i);
+    expect(r.fillerPerCapsuleMg).toBe(0);
+  });
+
+  test("missing size → prompt warning", () => {
+    const r = fillerPlan({ sizeKey: "", densityGPerMl: 0.6, activeDoseMg: 10, numCapsules: 10 });
+    expect(r.warning).toMatch(/density/i);
+  });
+});
+
+describe("costPer", () => {
+  test("cost per capsule and per day", () => {
+    const r = costPer({ bagCost: 40, capsules: 200, dosesPerDay: 2 });
+    expect(r.perCapsule).toBe(0.2);
+    expect(r.perDay).toBe(0.4);
+  });
+
+  test("zero capsules → 0, null per-day when no schedule", () => {
+    const r = costPer({ bagCost: 40, capsules: 0 });
+    expect(r.perCapsule).toBe(0);
+    expect(r.perDay).toBeNull();
+  });
+});
+
+describe("formatMass", () => {
+  test("chooses readable unit", () => {
+    expect(formatMass(500)).toBe("500 mg");
+    expect(formatMass(2500)).toBe("2.5 g");
+    expect(formatMass(0.5)).toBe("500 mcg");
+  });
+});

--- a/frontend/src/lib/capsuleCalc.js
+++ b/frontend/src/lib/capsuleCalc.js
@@ -1,0 +1,175 @@
+// Capsule maker calculator — pure functions for hand-filling capsules from
+// bulk powder. No React / no side effects, mirroring taperEngine.js so the math
+// is trivially unit-testable. Defensive like predictor.js: never throw on bad
+// input — return zeros (and, where relevant, a `warning` string).
+
+// Standard empty gelatin/HPMC capsule sizes → nominal fill volume in millilitres.
+// (Common reference values; actual capacity varies a little by brand.)
+export const CAPSULE_SIZES = {
+  "000": 1.37,
+  "00": 0.95,
+  "0": 0.68,
+  "1": 0.5,
+  "2": 0.37,
+  "3": 0.3,
+  "4": 0.21,
+  "5": 0.13,
+};
+
+// Ordered largest → smallest, for building reference tables / size suggestions.
+export const CAPSULE_SIZE_ORDER = ["000", "00", "0", "1", "2", "3", "4", "5"];
+
+// Approximate bulk (poured) powder densities in g/mL. These are rough guides —
+// users can override with a measured value.
+export const DENSITY_PRESETS = {
+  "light/fluffy": 0.3,
+  fine: 0.5,
+  typical: 0.6,
+  "dense/crystalline": 0.85,
+};
+
+// Mass units → milligrams. Grain (gr) is included because apothecary/compounding
+// recipes still use it.
+export const MASS_UNITS = {
+  mcg: 0.001,
+  mg: 1,
+  g: 1000,
+  gr: 64.79891,
+  oz: 28349.523125,
+};
+
+export const MASS_UNIT_ORDER = ["mcg", "mg", "g", "gr", "oz"];
+
+function num(x) {
+  const n = Number(x);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function round(x, dp = 2) {
+  const f = Math.pow(10, dp);
+  return Math.round(num(x) * f) / f;
+}
+
+// ---- unit conversion ----
+
+export function toMg(amount, unit) {
+  const factor = MASS_UNITS[unit] ?? 1;
+  return num(amount) * factor;
+}
+
+export function fromMg(mg, unit) {
+  const factor = MASS_UNITS[unit] ?? 1;
+  if (factor === 0) return 0;
+  return num(mg) / factor;
+}
+
+// Convert between any two supported mass units.
+export function convertMass(amount, fromUnit, toUnit) {
+  return fromMg(toMg(amount, fromUnit), toUnit);
+}
+
+// ---- capsule capacity ----
+
+// Milligrams of powder a given capsule size holds at a given powder density.
+// capacity(mg) = volume(mL) × density(g/mL) × 1000(mg/g)
+export function capsuleCapacityMg(sizeKey, densityGPerMl) {
+  const vol = CAPSULE_SIZES[sizeKey];
+  if (vol == null) return 0;
+  return round(vol * num(densityGPerMl) * 1000, 1);
+}
+
+// ---- core: bag of powder → number of capsules ----
+
+// totalAmount/totalUnit: the whole bag. fillPerCapsuleMg: intended active dose
+// per capsule (mg). purityPct: % of the powder that is the active substance
+// (100 = pure). Material actually weighed per capsule = dose / purity.
+export function bagToCapsules({ totalAmount, totalUnit = "mg", fillPerCapsuleMg, purityPct = 100 }) {
+  const totalMaterialMg = toMg(totalAmount, totalUnit);
+  const purity = num(purityPct);
+  const dose = num(fillPerCapsuleMg);
+  const materialPerCapsuleMg = purity > 0 ? dose / (purity / 100) : 0;
+
+  if (materialPerCapsuleMg <= 0 || totalMaterialMg <= 0) {
+    return { capsules: 0, totalMaterialMg: round(totalMaterialMg, 3), materialPerCapsuleMg: 0, leftoverMg: round(totalMaterialMg, 3), totalActiveMg: 0 };
+  }
+
+  const capsules = Math.floor(totalMaterialMg / materialPerCapsuleMg);
+  const leftoverMg = totalMaterialMg - capsules * materialPerCapsuleMg;
+  return {
+    capsules,
+    totalMaterialMg: round(totalMaterialMg, 3),
+    materialPerCapsuleMg: round(materialPerCapsuleMg, 3),
+    leftoverMg: round(leftoverMg, 3),
+    totalActiveMg: round(capsules * dose, 3),
+  };
+}
+
+// ---- reverse: target N capsules → powder needed ----
+
+export function capsulesToPowder({ numCapsules, fillPerCapsuleMg, purityPct = 100 }) {
+  const n = Math.max(0, Math.floor(num(numCapsules)));
+  const purity = num(purityPct);
+  const dose = num(fillPerCapsuleMg);
+  const materialPerCapsuleMg = purity > 0 ? dose / (purity / 100) : 0;
+  return {
+    totalMaterialMg: round(n * materialPerCapsuleMg, 3),
+    totalActiveMg: round(n * dose, 3),
+    materialPerCapsuleMg: round(materialPerCapsuleMg, 3),
+  };
+}
+
+// ---- filler / dilution planner (volumetric dosing / trituration) ----
+
+// When the active dose is small relative to what a capsule holds, blend it with
+// an inert filler so every capsule fills evenly and doses uniformly. Returns
+// per-capsule and batch masses, plus a warning when the dose won't fit.
+export function fillerPlan({ sizeKey, densityGPerMl, activeDoseMg, purityPct = 100, numCapsules }) {
+  const capacityMg = capsuleCapacityMg(sizeKey, densityGPerMl);
+  const purity = num(purityPct);
+  const dose = num(activeDoseMg);
+  const materialPerCapsuleMg = purity > 0 ? dose / (purity / 100) : 0;
+  const n = Math.max(0, Math.floor(num(numCapsules)));
+
+  let warning = "";
+  let fillerPerCapsuleMg = capacityMg - materialPerCapsuleMg;
+  if (capacityMg <= 0) {
+    warning = "Enter a capsule size and powder density to estimate capacity.";
+    fillerPerCapsuleMg = 0;
+  } else if (materialPerCapsuleMg >= capacityMg) {
+    warning = "The active material won't fit in this capsule size — use a larger capsule, split the dose, or increase potency.";
+    fillerPerCapsuleMg = 0;
+  }
+
+  return {
+    capacityMg,
+    materialPerCapsuleMg: round(materialPerCapsuleMg, 3),
+    fillerPerCapsuleMg: round(Math.max(0, fillerPerCapsuleMg), 3),
+    totalActiveMg: round(n * dose, 3),
+    totalMaterialMg: round(n * materialPerCapsuleMg, 3),
+    totalFillerMg: round(n * Math.max(0, fillerPerCapsuleMg), 3),
+    warning,
+  };
+}
+
+// ---- cost ----
+
+export function costPer({ bagCost, capsules, dosesPerDay }) {
+  const cost = num(bagCost);
+  const n = Math.max(0, Math.floor(num(capsules)));
+  const perCapsule = n > 0 ? cost / n : 0;
+  const perDay = num(dosesPerDay) > 0 ? perCapsule * num(dosesPerDay) : null;
+  return {
+    perCapsule: round(perCapsule, 4),
+    perDay: perDay == null ? null : round(perDay, 4),
+  };
+}
+
+// ---- formatting helper for UI (mg → friendly unit string) ----
+
+// Picks a readable unit: mg under 1000, otherwise g.
+export function formatMass(mg, dp = 2) {
+  const v = num(mg);
+  if (Math.abs(v) >= 1000) return `${round(v / 1000, dp)} g`;
+  if (Math.abs(v) > 0 && Math.abs(v) < 1) return `${round(v * 1000, 0)} mcg`;
+  return `${round(v, dp)} mg`;
+}

--- a/frontend/src/pages/CapsuleCalculator.jsx
+++ b/frontend/src/pages/CapsuleCalculator.jsx
@@ -1,0 +1,432 @@
+import { useState, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import PageHeader from "@/components/PageHeader";
+import EmptyState from "@/components/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { getMedications, adjustInventory } from "@/lib/api";
+import {
+  CAPSULE_SIZES,
+  CAPSULE_SIZE_ORDER,
+  DENSITY_PRESETS,
+  MASS_UNIT_ORDER,
+  bagToCapsules,
+  capsulesToPowder,
+  fillerPlan,
+  capsuleCapacityMg,
+  costPer,
+  formatMass,
+} from "@/lib/capsuleCalc";
+import { CAPSULE } from "@/constants/testIds";
+import { cn } from "@/lib/utils";
+import { FlaskConical, Copy, PackagePlus, AlertTriangle, ShieldAlert, Pill } from "lucide-react";
+
+const STORAGE_KEY = "meditrax:capsuleCalc";
+
+const DEFAULTS = {
+  totalAmount: 10,
+  totalUnit: "g",
+  fillPerCapsule: 250,
+  purity: 100,
+  densityPreset: "typical",
+  customDensity: "",
+  sizeKey: "0",
+  // reverse
+  numCapsules: 100,
+  revFill: 200,
+  revPurity: 100,
+  // filler
+  fillerSize: "0",
+  fillerDose: 10,
+  fillerBatch: 30,
+  // cost
+  bagCost: "",
+  dosesPerDay: "",
+};
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    /* ignore corrupt storage */
+  }
+  return { ...DEFAULTS };
+}
+
+// Small labelled field used throughout the calculator.
+function Field({ label, hint, children }) {
+  return (
+    <div>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div className="mt-1">{children}</div>
+      {hint && <p className="mt-1 text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+function Stat({ label, value, big }) {
+  return (
+    <div className="text-center">
+      <p className={cn("font-display font-semibold tabular-nums", big ? "text-4xl leading-none" : "text-xl")}>{value}</p>
+      <p className="text-xs text-muted-foreground mt-1">{label}</p>
+    </div>
+  );
+}
+
+export default function CapsuleCalculator() {
+  const [s, setS] = useState(loadState);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const set = (patch) => setS((prev) => ({ ...prev, ...patch }));
+  const setNum = (k) => (e) => set({ [k]: e.target.value === "" ? "" : Number(e.target.value) });
+
+  // Persist inputs so the calculator remembers where you left off.
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    } catch {
+      /* storage may be unavailable (private mode) — ignore */
+    }
+  }, [s]);
+
+  const density = useMemo(() => {
+    const custom = Number(s.customDensity);
+    if (s.customDensity !== "" && Number.isFinite(custom) && custom > 0) return custom;
+    return DENSITY_PRESETS[s.densityPreset] ?? 0.6;
+  }, [s.customDensity, s.densityPreset]);
+
+  const bag = useMemo(
+    () => bagToCapsules({ totalAmount: s.totalAmount, totalUnit: s.totalUnit, fillPerCapsuleMg: s.fillPerCapsule, purityPct: s.purity }),
+    [s.totalAmount, s.totalUnit, s.fillPerCapsule, s.purity]
+  );
+  const reverse = useMemo(
+    () => capsulesToPowder({ numCapsules: s.numCapsules, fillPerCapsuleMg: s.revFill, purityPct: s.revPurity }),
+    [s.numCapsules, s.revFill, s.revPurity]
+  );
+  const filler = useMemo(
+    () => fillerPlan({ sizeKey: s.fillerSize, densityGPerMl: density, activeDoseMg: s.fillerDose, numCapsules: s.fillerBatch }),
+    [s.fillerSize, density, s.fillerDose, s.fillerBatch]
+  );
+  const cost = useMemo(() => costPer({ bagCost: s.bagCost, capsules: bag.capsules, dosesPerDay: s.dosesPerDay }), [s.bagCost, bag.capsules, s.dosesPerDay]);
+
+  const selectedCapacity = capsuleCapacityMg(s.sizeKey, density);
+  const bagFillExceeds = selectedCapacity > 0 && bag.materialPerCapsuleMg > selectedCapacity;
+
+  const copySummary = async () => {
+    const lines = [
+      "Capsule Calculator — Meditrax",
+      `Bag: ${s.totalAmount} ${s.totalUnit}${s.purity < 100 ? ` @ ${s.purity}% potency` : ""}`,
+      `Fill: ${s.fillPerCapsule} mg active/capsule (${formatMass(bag.materialPerCapsuleMg)} powder/capsule)`,
+      `→ ${bag.capsules} capsules, ${formatMass(bag.leftoverMg)} left over`,
+      cost.perCapsule > 0 ? `Cost: ${cost.perCapsule.toFixed(4)}/capsule${cost.perDay != null ? `, ${cost.perDay.toFixed(4)}/day` : ""}` : null,
+    ].filter(Boolean);
+    try {
+      await navigator.clipboard.writeText(lines.join("\n"));
+      toast.success("Summary copied");
+    } catch {
+      toast.error("Couldn't copy to clipboard");
+    }
+  };
+
+  return (
+    <div>
+      <PageHeader title="Capsule Calculator" subtitle="Hand-fill capsules from bulk powder" back />
+      <div className="px-4 space-y-3 pb-tabbar">
+        {/* Safety note */}
+        <div className="card-soft p-3 flex gap-2.5 items-start bg-amber-500/5 border-amber-500/30">
+          <ShieldAlert className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Estimates only — hand-filled capsules are as accurate as your scale. Weigh with a milligram scale, never eyeball potent
+            substances. Educational tool, not medical advice.{" "}
+            <Link to="/legal/disclaimer" className="text-primary underline underline-offset-2">
+              Read the disclaimer
+            </Link>
+            .
+          </p>
+        </div>
+
+        <Tabs defaultValue="bag" className="w-full">
+          <TabsList className="grid w-full grid-cols-3 h-auto">
+            <TabsTrigger value="bag" className="text-xs py-2">Bag → Capsules</TabsTrigger>
+            <TabsTrigger value="reverse" className="text-xs py-2">Capsules → Powder</TabsTrigger>
+            <TabsTrigger value="filler" className="text-xs py-2">Filler / Dilution</TabsTrigger>
+          </TabsList>
+
+          {/* ---- Bag → Capsules ---- */}
+          <TabsContent value="bag" className="mt-3 space-y-3">
+            <div className="card-soft p-4 space-y-3">
+              <div className="grid grid-cols-3 gap-2">
+                <div className="col-span-2">
+                  <Field label="Bag / total powder">
+                    <Input type="number" min="0" value={s.totalAmount} onChange={setNum("totalAmount")} data-testid={CAPSULE.totalInput} className="h-11 rounded-xl" />
+                  </Field>
+                </div>
+                <Field label="Unit">
+                  <Select value={s.totalUnit} onValueChange={(v) => set({ totalUnit: v })}>
+                    <SelectTrigger data-testid={CAPSULE.totalUnitSelect} className="h-11 rounded-xl"><SelectValue /></SelectTrigger>
+                    <SelectContent>{MASS_UNIT_ORDER.map((u) => <SelectItem key={u} value={u}>{u}</SelectItem>)}</SelectContent>
+                  </Select>
+                </Field>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Active dose / capsule (mg)">
+                  <Input type="number" min="0" value={s.fillPerCapsule} onChange={setNum("fillPerCapsule")} data-testid={CAPSULE.fillInput} className="h-11 rounded-xl" />
+                </Field>
+                <Field label="Potency / purity (%)" hint="100 = pure active">
+                  <Input type="number" min="0" max="100" value={s.purity} onChange={setNum("purity")} data-testid={CAPSULE.purityInput} className="h-11 rounded-xl" />
+                </Field>
+              </div>
+
+              {/* Capsule-size helper: auto-fill dose from capacity */}
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Capsule size (optional)">
+                  <Select
+                    value={s.sizeKey}
+                    onValueChange={(v) => set({ sizeKey: v, fillPerCapsule: Math.round(capsuleCapacityMg(v, density) * (Number(s.purity) || 100) / 100) })}
+                  >
+                    <SelectTrigger data-testid={CAPSULE.sizeSelect} className="h-11 rounded-xl"><SelectValue placeholder="Size" /></SelectTrigger>
+                    <SelectContent>
+                      {CAPSULE_SIZE_ORDER.map((k) => <SelectItem key={k} value={k}>Size {k} · {CAPSULE_SIZES[k]} mL</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </Field>
+                <Field label="Powder density" hint={`≈ ${density} g/mL · capacity ${formatMass(selectedCapacity)}`}>
+                  <Select value={s.densityPreset} onValueChange={(v) => set({ densityPreset: v, customDensity: "" })}>
+                    <SelectTrigger data-testid={CAPSULE.densitySelect} className="h-11 rounded-xl"><SelectValue /></SelectTrigger>
+                    <SelectContent>{Object.keys(DENSITY_PRESETS).map((k) => <SelectItem key={k} value={k}>{k}</SelectItem>)}</SelectContent>
+                  </Select>
+                </Field>
+              </div>
+
+              <p className="text-[11px] text-muted-foreground -mt-1">
+                Tip: picking a size fills the dose with the max powder that size holds. Override the density with a measured value below.
+              </p>
+              <Input
+                type="number" min="0" step="0.05" placeholder="Custom density g/mL (optional)"
+                value={s.customDensity} onChange={(e) => set({ customDensity: e.target.value })}
+                data-testid={CAPSULE.densityCustomInput} className="h-10 rounded-xl"
+              />
+            </div>
+
+            {/* Result */}
+            <div className="card-soft p-4">
+              <div className="grid grid-cols-3 gap-2 items-end">
+                <Stat label="capsules" value={<span data-testid={CAPSULE.resultCount}>{bag.capsules}</span>} big />
+                <Stat label="powder / capsule" value={formatMass(bag.materialPerCapsuleMg)} />
+                <Stat label="left over" value={formatMass(bag.leftoverMg)} />
+              </div>
+              <div className="mt-3 pt-3 border-t border-border grid grid-cols-2 gap-2 text-sm">
+                <div className="flex justify-between"><span className="text-muted-foreground">Total active</span><span className="font-medium">{formatMass(bag.totalActiveMg)}</span></div>
+                {cost.perCapsule > 0 && (
+                  <div className="flex justify-between"><span className="text-muted-foreground">Per capsule</span><span className="font-medium">{cost.perCapsule.toFixed(4)}</span></div>
+                )}
+              </div>
+
+              {bagFillExceeds && (
+                <div className="mt-3 flex gap-2 items-start rounded-xl bg-amber-500/10 p-2.5 text-xs text-amber-700">
+                  <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <span>{formatMass(bag.materialPerCapsuleMg)} won't fit a size {s.sizeKey} capsule ({formatMass(selectedCapacity)}). Use a larger capsule or split the dose.</span>
+                </div>
+              )}
+
+              <div className="mt-3 flex gap-2">
+                <Button variant="secondary" className="flex-1 h-11 rounded-xl" onClick={copySummary} data-testid={CAPSULE.copyButton}>
+                  <Copy className="h-4 w-4 mr-1.5" />Copy
+                </Button>
+                <Button className="flex-1 h-11 rounded-xl" onClick={() => setSaveOpen(true)} disabled={bag.capsules <= 0} data-testid={CAPSULE.saveInventoryButton}>
+                  <PackagePlus className="h-4 w-4 mr-1.5" />To inventory
+                </Button>
+              </div>
+            </div>
+
+            {/* Cost inputs */}
+            <div className="card-soft p-4">
+              <p className="text-sm font-semibold mb-2">Cost (optional)</p>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Bag cost">
+                  <Input type="number" min="0" step="0.01" placeholder="e.g. 24.99" value={s.bagCost} onChange={(e) => set({ bagCost: e.target.value })} data-testid={CAPSULE.bagCostInput} className="h-11 rounded-xl" />
+                </Field>
+                <Field label="Capsules / day" hint="for cost-per-day">
+                  <Input type="number" min="0" placeholder="e.g. 2" value={s.dosesPerDay} onChange={(e) => set({ dosesPerDay: e.target.value })} className="h-11 rounded-xl" />
+                </Field>
+              </div>
+              {cost.perCapsule > 0 && (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  ≈ <span className="font-medium text-foreground">{cost.perCapsule.toFixed(4)}</span> per capsule
+                  {cost.perDay != null && <> · <span className="font-medium text-foreground">{cost.perDay.toFixed(2)}</span> per day</>}
+                </p>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* ---- Capsules → Powder ---- */}
+          <TabsContent value="reverse" className="mt-3 space-y-3">
+            <div className="card-soft p-4 space-y-3">
+              <div className="grid grid-cols-3 gap-2">
+                <Field label="Capsules wanted">
+                  <Input type="number" min="0" value={s.numCapsules} onChange={setNum("numCapsules")} data-testid={CAPSULE.capsulesInput} className="h-11 rounded-xl" />
+                </Field>
+                <Field label="Active / capsule (mg)">
+                  <Input type="number" min="0" value={s.revFill} onChange={setNum("revFill")} className="h-11 rounded-xl" />
+                </Field>
+                <Field label="Purity (%)">
+                  <Input type="number" min="0" max="100" value={s.revPurity} onChange={setNum("revPurity")} className="h-11 rounded-xl" />
+                </Field>
+              </div>
+            </div>
+            <div className="card-soft p-4 grid grid-cols-2 gap-2">
+              <Stat label="powder needed" value={formatMass(reverse.totalMaterialMg)} big />
+              <Stat label="total active" value={formatMass(reverse.totalActiveMg)} />
+            </div>
+          </TabsContent>
+
+          {/* ---- Filler / Dilution ---- */}
+          <TabsContent value="filler" className="mt-3 space-y-3">
+            <div className="card-soft p-4 space-y-3">
+              <p className="text-xs text-muted-foreground">
+                For small doses: blend the active with an inert filler (e.g. rice flour, microcrystalline cellulose) so each capsule fills
+                evenly and doses uniformly.
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Capsule size">
+                  <Select value={s.fillerSize} onValueChange={(v) => set({ fillerSize: v })}>
+                    <SelectTrigger className="h-11 rounded-xl"><SelectValue /></SelectTrigger>
+                    <SelectContent>{CAPSULE_SIZE_ORDER.map((k) => <SelectItem key={k} value={k}>Size {k} · {CAPSULE_SIZES[k]} mL</SelectItem>)}</SelectContent>
+                  </Select>
+                </Field>
+                <Field label="Density" hint={`≈ ${density} g/mL`}>
+                  <Select value={s.densityPreset} onValueChange={(v) => set({ densityPreset: v, customDensity: "" })}>
+                    <SelectTrigger className="h-11 rounded-xl"><SelectValue /></SelectTrigger>
+                    <SelectContent>{Object.keys(DENSITY_PRESETS).map((k) => <SelectItem key={k} value={k}>{k}</SelectItem>)}</SelectContent>
+                  </Select>
+                </Field>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Active dose / capsule (mg)">
+                  <Input type="number" min="0" value={s.fillerDose} onChange={setNum("fillerDose")} className="h-11 rounded-xl" />
+                </Field>
+                <Field label="Batch size (capsules)">
+                  <Input type="number" min="0" value={s.fillerBatch} onChange={setNum("fillerBatch")} className="h-11 rounded-xl" />
+                </Field>
+              </div>
+            </div>
+
+            {filler.warning ? (
+              <div className="card-soft p-4 flex gap-2 items-start bg-amber-500/10 border-amber-500/30">
+                <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+                <p className="text-sm text-amber-700">{filler.warning}</p>
+              </div>
+            ) : (
+              <div className="card-soft p-4 space-y-3">
+                <div className="grid grid-cols-3 gap-2">
+                  <Stat label="filler / capsule" value={formatMass(filler.fillerPerCapsuleMg)} big />
+                  <Stat label="active / capsule" value={formatMass(filler.materialPerCapsuleMg)} />
+                  <Stat label="capacity" value={formatMass(filler.capacityMg)} />
+                </div>
+                <div className="pt-3 border-t border-border grid grid-cols-2 gap-2 text-sm">
+                  <div className="flex justify-between"><span className="text-muted-foreground">Total filler</span><span className="font-medium">{formatMass(filler.totalFillerMg)}</span></div>
+                  <div className="flex justify-between"><span className="text-muted-foreground">Total active</span><span className="font-medium">{formatMass(filler.totalActiveMg)}</span></div>
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  Mix {formatMass(filler.totalActiveMg)} active with {formatMass(filler.totalFillerMg)} filler thoroughly, then fill {s.fillerBatch} capsules.
+                </p>
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+
+        {/* Capsule size reference */}
+        <div className="card-soft overflow-hidden">
+          <p className="px-4 pt-3 pb-2 text-sm font-semibold">Capsule size reference</p>
+          <div className="grid grid-cols-3 text-xs font-medium text-muted-foreground px-4 pb-1">
+            <span>Size</span><span className="text-right">Volume</span><span className="text-right">Capacity ≈</span>
+          </div>
+          <div className="divide-y divide-border">
+            {CAPSULE_SIZE_ORDER.map((k) => (
+              <div key={k} className={cn("grid grid-cols-3 px-4 py-2 text-sm", k === s.sizeKey && "bg-primary/5")}>
+                <span className="font-medium">{k}</span>
+                <span className="text-right tabular-nums">{CAPSULE_SIZES[k]} mL</span>
+                <span className="text-right tabular-nums">{formatMass(capsuleCapacityMg(k, density))}</span>
+              </div>
+            ))}
+          </div>
+          <p className="px-4 py-2 text-[11px] text-muted-foreground">Capacity shown at ≈ {density} g/mL (from the density you selected).</p>
+        </div>
+      </div>
+
+      <SaveToInventoryDrawer open={saveOpen} onClose={() => setSaveOpen(false)} capsules={bag.capsules} />
+    </div>
+  );
+}
+
+function SaveToInventoryDrawer({ open, onClose, capsules }) {
+  const qc = useQueryClient();
+  const { data: meds = [] } = useQuery({ queryKey: ["medications"], queryFn: () => getMedications() });
+  const capsuleMeds = useMemo(() => meds.filter((m) => m.form === "capsule"), [meds]);
+  const [medId, setMedId] = useState("");
+  const [mode, setMode] = useState("set"); // set | add
+
+  useEffect(() => { if (open) { setMedId(capsuleMeds[0]?.id || ""); setMode("set"); } }, [open]); // eslint-disable-line
+
+  const save = useMutation({
+    mutationFn: () => adjustInventory(medId, mode === "set" ? { set: capsules } : { delta: capsules }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["inventory"] });
+      qc.invalidateQueries({ queryKey: ["medications"] });
+      toast.success(`Saved ${capsules} capsules to inventory`);
+      onClose();
+    },
+    onError: () => toast.error("Could not update inventory"),
+  });
+
+  return (
+    <Drawer open={open} onOpenChange={(o) => !o && onClose()}>
+      <DrawerContent className="max-w-2xl mx-auto">
+        <div className="mx-auto mt-2 h-1 w-10 rounded-full bg-muted" />
+        <DrawerHeader className="text-left"><DrawerTitle className="font-display text-2xl">Save to inventory</DrawerTitle></DrawerHeader>
+        <div className="px-4 pb-2">
+          {capsuleMeds.length === 0 ? (
+            <EmptyState
+              icon={Pill}
+              title="No capsule medications"
+              description="Add a medication with the “capsule” form first, then you can push this count to its inventory."
+            />
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground mb-3">
+                Applying <span className="font-semibold text-foreground">{capsules}</span> capsules.
+              </p>
+              <Label className="text-xs text-muted-foreground">Medication</Label>
+              <Select value={medId} onValueChange={setMedId}>
+                <SelectTrigger data-testid={CAPSULE.medSelect} className="h-11 rounded-xl mt-1"><SelectValue placeholder="Choose" /></SelectTrigger>
+                <SelectContent>{capsuleMeds.map((m) => <SelectItem key={m.id} value={m.id}>{m.name}</SelectItem>)}</SelectContent>
+              </Select>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <button onClick={() => setMode("set")} className={cn("h-11 rounded-xl border text-sm font-medium", mode === "set" ? "border-primary bg-primary/10 text-primary" : "border-border")}>Set to {capsules}</button>
+                <button onClick={() => setMode("add")} className={cn("h-11 rounded-xl border text-sm font-medium", mode === "add" ? "border-primary bg-primary/10 text-primary" : "border-border")}>Add {capsules}</button>
+              </div>
+            </>
+          )}
+        </div>
+        <div className="p-4 safe-bottom flex gap-3">
+          <Button variant="secondary" className="flex-1 h-12 rounded-xl" onClick={onClose}>Cancel</Button>
+          <Button
+            className="flex-1 h-12 rounded-xl"
+            disabled={!medId || save.isPending || capsuleMeds.length === 0}
+            onClick={() => save.mutate()}
+            data-testid={CAPSULE.saveInventoryConfirm}
+          >
+            {save.isPending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/frontend/src/pages/More.jsx
+++ b/frontend/src/pages/More.jsx
@@ -1,12 +1,13 @@
 import { Link } from "react-router-dom";
 import PageHeader from "@/components/PageHeader";
-import { CalendarDays, TrendingDown, RefreshCw, Package, BookOpen, Sparkles, Activity, Bell, User, Settings as SettingsIcon, ChevronRight, ShieldCheck, FileText, Stethoscope } from "lucide-react";
+import { CalendarDays, TrendingDown, RefreshCw, Package, BookOpen, Sparkles, Activity, Bell, User, Settings as SettingsIcon, ChevronRight, ShieldCheck, FileText, Stethoscope, FlaskConical } from "lucide-react";
 
 const ITEMS = [
   { to: "/calendar", label: "Calendar", desc: "Adherence history", icon: CalendarDays, testid: "more-calendar" },
   { to: "/taper", label: "Taper Planner", desc: "Plan dose reductions", icon: TrendingDown, testid: "more-taper" },
   { to: "/cyclic", label: "Cyclic Dosing", desc: "On/off cycles", icon: RefreshCw, testid: "more-cyclic" },
   { to: "/inventory", label: "Inventory", desc: "Stock & refills", icon: Package, testid: "more-inventory" },
+  { to: "/capsules", label: "Capsule Calculator", desc: "Fill capsules from bulk powder", icon: FlaskConical, testid: "more-capsules" },
   { to: "/knowledge", label: "Knowledge Base", desc: "Medication library", icon: BookOpen, testid: "more-knowledge" },
   { to: "/assistant", label: "AI Assistant", desc: "Ask anything", icon: Sparkles, testid: "more-assistant" },
   { to: "/effects", label: "Effects & Journal", desc: "Mood & effectiveness", icon: Activity, testid: "more-effects" },


### PR DESCRIPTION
Adds a new tool that computes how many capsules a bag of powder yields,
plus related compounding utilities:

- Bag -> Capsules: total powder + active dose/capsule + purity -> capsule
  count, powder per capsule, and leftover, with capsule-size capacity
  awareness and an overfill warning.
- Capsules -> Powder (reverse): target batch -> powder needed.
- Filler / Dilution planner: for small doses, how much inert filler to
  blend per capsule and per batch (volumetric dosing), with a "won't fit"
  warning when the dose exceeds capsule capacity.
- Capsule-size reference table (000-5) with density-aware capacity.
- Purity %, mg/mcg/g/gr/oz unit handling, cost per capsule/day, copy
  summary to clipboard, and remembered inputs via localStorage.
- "Save to inventory": push the computed count onto a capsule-form
  medication via adjustInventory.

Math lives in a pure-function lib (lib/capsuleCalc.js) with full unit
tests; the page reuses existing UI primitives and the More menu entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ha7d5THcjGW1CGeUiY2cnh